### PR TITLE
Using  before it's overwritten with mysqli_query result

### DIFF
--- a/announce.php
+++ b/announce.php
@@ -394,10 +394,10 @@ function start($info_hash, $ip, $port, $peer_id, $left, $downloaded=0, $uploaded
     else
         $ip = getip();
 
+    $remotedns = gethostbyaddr($ip);
     $ip =  mysqli_query($GLOBALS['conn'],$ip);
     $agent =  mysqli_query($GLOBALS['conn'],$_SERVER["HTTP_USER_AGENT"]);
-    $remotedns = gethostbyaddr($ip);
-
+    
     if (isset($_GET["ip"])) $nuIP = $_GET["ip"];
       else $nuIP = "";
     if ($remotedns == $nuIP)


### PR DESCRIPTION
I was getting bencode parsing failures in rtorrent and `PHP Warning:  gethostbyaddr(): Address is not a valid IPv4 or IPv6 address in .../announce.php on line 399` for each `announce.php` request before this change.

Fresh xbtit install, `$ip` was being set to `false` on line 397.