### PR TITLE
comment.tpl: encode ampersand

### DIFF
--- a/style/xbtit_default/comment.tpl
+++ b/style/xbtit_default/comment.tpl
@@ -16,7 +16,7 @@
   </div>
   <div class="panel-body">
 <div align="center">
-  <form enctype="multipart/form-data" name="comment" method="post" action="index.php?page=comment&id=<tag:comment_id />">
+  <form enctype="multipart/form-data" name="comment" method="post" action="index.php?page=comment&amp;id=<tag:comment_id />">
   <input type="hidden" name="info_hash" value="<tag:comment_id />" />
     <table class="lista" border="0" cellpadding="10" width="100%">
       <tr>


### PR DESCRIPTION
While browsing comment.tpl on GitHub, an unencoded ampersand was caught by the syntax highlighter and displayed as dark red. And dark red means "Danger, Will Robinson!". So I've adjusted it without really knowing what I'm doing or testing it. Nor have I tried any a linting utility to see if there's more of these laying around.