### PR TITLE
Fix CVE-2018-15683 and another open redirect

### DIFF
--- a/account_change.php
+++ b/account_change.php
@@ -37,6 +37,8 @@ $style = isset($_GET['style']) ? ((int)$_GET['style']) : 0;
 $url = isset($_GET['returnto']) ? urldecode($_GET['returnto']) : 'index.php';
 $langue = isset($_GET['langue']) ? ((int)$_GET['langue']) : 0;
 
+$url = $BASEURL.'/'.$url;
+
 dbconn();
 session_name('xbtit');
 session_start();

--- a/login.php
+++ b/login.php
@@ -156,7 +156,7 @@ if (!$CURUSER || $CURUSER["uid"]==1)
                         set_ipb_cookie($row["ipb_fid"]);
                 }
                 if (isset($_GET["returnto"]))
-                    $url=urldecode($_GET["returnto"]);
+                    $url=$BASEURL.'/'.urldecode($_GET["returnto"]);
                 else
                     $url="index.php";
                 redirect($url);
@@ -182,7 +182,7 @@ if (!$CURUSER || $CURUSER["uid"]==1)
 else
 {
     if (isset($_GET["returnto"]))
-        $url=urldecode($_GET["returnto"]);
+        $url=$BASEURL.'/'.urldecode($_GET["returnto"]);
     else
         $url="index.php";
     redirect($url);


### PR DESCRIPTION
This change fixes the open redirect previously disclosed under CVE-2018-15683 and fixes another that was identified within `account_change.php` (CVE-2018-17870)