### PR TITLE
Fix CVE-2018-15684

### DIFF
--- a/sql/database.sql
+++ b/sql/database.sql
@@ -961,7 +961,7 @@ INSERT INTO `{$db_prefix}settings` (`key`, `value`) VALUES
 ('secsui_cookie_items', '1-0,2-0,3-0,4-0,5-0,6-0,7-0,8-0[+]0'),
 ('secsui_pass_min_req', '4,0,0,0,0'),
 ('ipb_autoposter', '0'),
-('php_log_name', 'xbtit-errors'),
+('php_log_name', CONCAT('xbtit-errors-', SUBSTRING(MD5(RAND()) FROM 1 FOR 16))),
 ('php_log_path', '/full/path/to/the/web/root/include/logs'),
 ('php_log_lines', '5');
 


### PR DESCRIPTION
This change fixes the issue previously disclosed regarding the unauthorised access to PHP log files via:

1. Predictable file names
2. Lack of directory index

The `index.html` file has been added to prevent the directory listing being displayed. The change to the database script will ensure that `xbtit-errors` remains the base name, but will append 16 characters (in the range of a-f and 0-9).

After completing an installation using these changes, the initial value of the log file can be seen to contain a random string below:

```shell_session
mysql> select * from xbtit3_settings where `key` = 'php_log_name';
+--------------+-------------------------------+
| key          | value                         |
+--------------+-------------------------------+
| php_log_name | xbtit-errors-e2a379d9314a8cb4 |
+--------------+-------------------------------+
1 row in set (0.00 sec)
```